### PR TITLE
chore: add OWNERS.md file with Duologic

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,0 +1,9 @@
+# OWNERS
+
+This page lists all maintainers for **this** repository. Each repository in the
+[Crossplane Contrib organization](https://github.com/crossplane-contrib/) will list their
+repository maintainers in their own `OWNERS.md` file.
+
+## Maintainers
+
+* Jeroen Op 't Eynde ([Duologic](https://github.com/Duologic))

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -7,3 +7,4 @@ repository maintainers in their own `OWNERS.md` file.
 ## Maintainers
 
 * Jeroen Op 't Eynde ([Duologic](https://github.com/Duologic))
+* Steven Borrelli ([stevendborrelli](https://github.com/stevendborrelli))


### PR DESCRIPTION
This PR simply adds an OWNERS.md file with @Duologic as the maintainer.

Helps out with #2 