### PR TITLE
Bump default version to v2.1.3

### DIFF
--- a/.github/workflows/test-setup-crossplane.yml
+++ b/.github/workflows/test-setup-crossplane.yml
@@ -51,7 +51,7 @@ jobs:
         uses: ./
         with:
           cache-prefix: ${{ env.CACHE_PREFIX }}
-          version: v1.18.1
+          version: v2.1.3
 
       - name: Assert cache
         if: fromJson(steps.setup-crossplane.outputs.cache-hit) != matrix.cache-hit

--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@ Setup Crossplane cli and add it to the PATH, this action will run the install ba
 
 ## Example
 
-```
+```yaml
 uses: crossplane-contrib/setup-crossplane-action@main
 with:
-  version: v1.18.1 # Version of the Crossplane CLI to install.
-
+  version: v2.1.3 # Version of the Crossplane CLI to install.
 ```

--- a/action.yaml
+++ b/action.yaml
@@ -9,7 +9,7 @@ inputs:
   version:
     description: |
       Version of the Crossplane CLI to install.
-    default: v1.18.1
+    default: v2.1.3
 
   channel:
     description: |
@@ -32,7 +32,7 @@ runs:
         path: ${{ github.workspace }}/bin/crossplane
         key: ${{ inputs.cache-prefix }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.version }}
 
-    - run: "curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | sh"
+    - run: "curl -sL https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh | sh"
       id: install
       shell: bash
       env:


### PR DESCRIPTION
The PR:
* bumps default Crossplane version to `v2.1.3` as the current latest version.
* fixes URL to the binary